### PR TITLE
Remove deliver method call to avoid 500 error on user create

### DIFF
--- a/lib/userscontroller_patch.rb
+++ b/lib/userscontroller_patch.rb
@@ -9,7 +9,7 @@ module UsersControllerPatch
 				@user.pref.safe_attributes = params[:pref]
 				
 				if @user.save
-					Mailer.deliver_account_information(@user, @user.password).deliver if params[:send_information]
+					Mailer.deliver_account_information(@user, @user.password) if params[:send_information]
 		
 	# ============= ERPmine_patch Redmine 4.1.1  =====================	
 					#Below code for save wk users


### PR DESCRIPTION
### Steps to reproduce
Create a new user on page `/users/new` with `Send account information to the user` checked.

### Expected behavior
Successfully create a user and redirect to user list

### Actual behavior
`Internal error` page was displayed, with error output in `log/production.log`:

```
Completed 500 Internal Server Error in 169ms (ActiveRecord: 140.6ms)

NoMethodError (undefined method `deliver' for #<ActionMailer::DeliveryJob:0x000055d2d7939770>):

plugins/redmine_wktime/lib/userscontroller_patch.rb:12:in `create'
lib/redmine/sudo_mode.rb:65:in `sudo_mode'
```

### System configuration
- Redmine version: 4.1.1.stable.20095
- Ruby version: 2.5.5-p157 (2019-03-15) [x86_64-linux-gnu]
- Rails version: 5.2.4.2
- Environment: production
- Database adapter: Mysql2
- Mailer queue: ActiveJob::QueueAdapters::AsyncAdapter
- Mailer delivery: smtp
- redmine_wktime: 4.0.4

### Fix

[app/models/mailer.rb:352](https://github.com/redmine/redmine/blob/e1a783af455a6b02a9ff72a78c855d57f473ed0a/app/models/mailer.rb#L352) in redmine 4.1.1 already called method `deliver_later`. It's therefore not required to call `deliver` method again in `lib/userscontroller_patch.rb:12`
