### PR TITLE
Edit Timesheet Pageload Performance

### DIFF
--- a/app/controllers/wktime_controller.rb
+++ b/app/controllers/wktime_controller.rb
@@ -134,15 +134,15 @@ include ActionView::Helpers::TagHelper
 		findWkTE(@startday)
 
 		# Getting allowed Project members
-		@users = []
-		members = []
 		projects = (@manage_projects || []).pluck(:id)
 		projects.concat((@manage_others_log || []).pluck(:id))
-		projects.each do |projID|
-			project = Project.find(projID)
-			project.members.each{|member| members << [member.user.name, member.user.id] }
-		end
-		members.each {|userID| @users << userID if userID && !@users.include?(userID) }
+
+		@users = User.includes(:members)
+			.joins("join members on users.id = members.user_id")
+			.where("members.project_id": projects)
+			.distinct
+			.map{|user| [user.name, user.id] }
+
 		if getSheetView == 'W'
 			getUserwkStatuses
 			getApproverPermProj


### PR DESCRIPTION
I've noticed a performance issue when loading the edit timesheet page, the request can become blocking if multiple users load the page simultaneously. It is more obvious when impersonating an admin account on a Redmine instance with lots of projects and users (see #242 for more details) .  The slowdown comes from the project list being iterated in Ruby, then each members of each projects being added to a list then deduped.

The solution is to make a single SQL query to get the users by filtering them by their projects (listed in the members table). That doesn't require looping through a large list and it has proven to be much more efficient. From the benchmark I've run on my production environment, pageload went from 4000~6000ms to to 500~800ms.