### PR TITLE
Bring back search dropdown to project input on timesheet edit page

### DIFF
--- a/app/views/wktime/_edit_issues2.html.erb
+++ b/app/views/wktime/_edit_issues2.html.erb
@@ -28,7 +28,7 @@
 				<% if @editable %>
 					<%=h select_tag(isTemplate ? '__template__time_entry[][project_id]' : 'time_entry[][project_id]',
 					options_for_select(projects, :selected =>  project_id),
-					:onchange => "projectChanged(this,#{@row.to_s()});", :style=> "width:150px" ) %>
+					:onchange => "projectChanged(this,#{@row.to_s()});", :style=> "width:150px", class: 'issueDD' ) %>
 				<% else %>
 					<% if project.blank? %>
 						<% if entry.nil? %>


### PR DESCRIPTION
Migrating from an older version of the plugin, I've noticed that users could not search in the project row field when creating/editing a timesheet anymore. It is particularly useful when having a lot of projects, I guess it would be great to add it back. 

It seems to work fine by just adding issueDD class to the input field.