### PR TITLE
Fix issue with the comment image elements losing their name attributes

### DIFF
--- a/app/views/wkexpense/edit.html.erb
+++ b/app/views/wkexpense/edit.html.erb
@@ -19,9 +19,6 @@
 			Setting.plugin_redmine_wktime['wktime_enter_comment_in_row'].to_i == 1 %>
 				commentInRow = true;
 		<% end %>
-		withCommantImg = '<%= image_tag('withcommant.png', plugin: 'redmine_wktime') %>';
-		withoutcommantImg = '<%= image_tag('withoutcommant.png', plugin: 'redmine_wktime') %>';
-
 	</script>
 
 	<div id="comment-dlg">

--- a/app/views/wktime/edit.html.erb
+++ b/app/views/wktime/edit.html.erb
@@ -43,8 +43,6 @@
 			Setting.plugin_redmine_wktime['wktime_enter_comment_in_row'].to_i == 1 %>
 				commentInRow = true;
 		<% end %>
-		withCommantImg = '<%= image_tag('withcommant.png', plugin: 'redmine_wktime') %>';
-		withoutcommantImg = '<%= image_tag('withoutcommant.png', plugin: 'redmine_wktime') %>';
 	</script>
 
 	<div id="comment-dlg">

--- a/assets/javascripts/edit.js
+++ b/assets/javascripts/edit.js
@@ -31,6 +31,8 @@ var minHourperWeekAlertMsg="";
 var maxHourperWeekAlertMsg="";
 var attachmentDiv = "";
 var attachmentField = "";
+var withCommantSrc = RAILS_ASSET_URL('/plugin_assets/redmine_wktime/withcommant.png');
+var withoutCommantSrc = RAILS_ASSET_URL('/plugin_assets/redmine_wktime/withoutcommant.png');
 
 $(document).ready(function() {
 	var e_comments = $( "#_edit_comments_" );
@@ -102,11 +104,11 @@ $(document).ready(function() {
 					var x = document.getElementsByName("custfield_img"+comment_row+"[]");
 					if( ((e_comments.val() != "" || custFldToolTip)  && (!commentInRow  || custFldToolTip )) || $("#attachment_" + comment_row + "_" + comment_col + " .attachments_fields").children().length > 0)
 					{
-						$(x[comment_col-1]).replaceWith(withCommantImg);
+						$(x[comment_col-1]).attr({src: withCommantSrc});
 					}
 					else
 					{
-						$(x[comment_col-1]).replaceWith(withoutcommantImg);
+						$(x[comment_col-1]).attr({src: withoutCommantSrc});
 					}
 					$(attachmentField).appendTo(attachmentDiv);
 					$( this ).dialog( "close" );


### PR DESCRIPTION
The aaeba13 commit unintentionally messes up how comments are handled, because it replaces the existing HTML entirely removing the `name` attribute, which then leads to edits matching against the wrong index.

Steps to reproduce:
* Attempt to book a time and expenses (`/wktime/edit?startday=2025-05-19&tab=wktime&user_id=1`), all on the same row
* Click Monday, and enter a comment, then press Ok.
* Press Monday again, and press Ok.
* Tuesday is now suddenly flagged as having a comment, even though it doesn't.
* Add a comment on Tuesday, and press Ok.
* Keep opening and closing the Tuesday comment a couple more times, and you won't be able to close the modal.