### PR TITLE
Fix 500 error in Doorkeeper-served views on Redmine 6.1+

### DIFF
--- a/app/views/wkbase/_base_header.html.erb
+++ b/app/views/wkbase/_base_header.html.erb
@@ -2,7 +2,7 @@
 <%= javascript_include_tag 'wkstatus', :plugin => "redmine_wktime" %>
 <%= stylesheet_link_tag 'lockwarning', :plugin => "redmine_wktime" %>
 <%= hidden_field_tag 'spent_time_user_id', User.current.id %>
-<%= hidden_field_tag 'getspenttype_url', url_for(:controller => 'wklogmaterial', :action => 'load_spent_type') %>
+<%= hidden_field_tag 'getspenttype_url', url_for(:controller => '/wklogmaterial', :action => 'load_spent_type') %>
 
 <!-- For SideBar theme -->
 <% if Setting.ui_theme.to_s.downcase == "sidebar" || (["sidebar_white", "sidebar-white"].include?(Setting.ui_theme.to_s.downcase)) %>


### PR DESCRIPTION
## Bug

On Redmine 6.1.0+ with OAuth/Doorkeeper enabled, navigating to any Doorkeeper-served user-facing view returns a 500. Affected views include:

- My account --> Authorized applications (`/oauth/authorized_applications`)
- The OAuth authorise page after sign-in (`/oauth/authorize`)

The application/admin-side OAuth views (`/oauth/applications`) work fine, because they use a different layout.

## Root cause

`app/views/wkbase/_base_header.html.erb` line 5 calls `url_for(:controller => 'wklogmaterial', ...)` with a relative controller string. When Rails renders Doorkeeper's user-facing views, the controller is in the `Doorkeeper::` namespace, and Rails resolves the relative path as `doorkeeper/wklogmaterial`, which doesn't exist. Result: `ActionController::UrlGenerationError`, 500.

The fix is to make the controller reference absolute by prefixing it with a leading slash: `'/wklogmaterial'`. This forces Rails to resolve it from the routing root regardless of the namespace of the current controller.

## Fix

```diff
- url_for(:controller => 'wklogmaterial', ...)
+ url_for(:controller => '/wklogmaterial', ...)
```

## Verification

Tested on:
- Redmine 6.1.1 + ERPmine 4.9.2 (staging) - fix resolves all 500s on Doorkeeper user views.
- Same Redmine + ERPmine combination in production - applied via the same patch, no regressions, OAuth flow now completes end-to-end.

The fix is identical in behaviour for non-OAuth users: the URL it generates resolves the same way whether or not Doorkeeper is the rendering controller.

## Affects

Any ERPmine deployment on Redmine 6.1+ where users access Doorkeeper-served OAuth views. Redmine 6.1 introduced Doorkeeper-based OAuth support, which is what surfaces this latent bug; older Redmine versions don't render these views with this controller context, so the bug is invisible there.